### PR TITLE
Implemented reset password

### DIFF
--- a/Code/.idea/misc.xml
+++ b/Code/.idea/misc.xml
@@ -6,7 +6,7 @@
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/drawable/splash_background.xml" value="0.1985" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/activity_main.xml" value="0.3625" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/fragment_settings.xml" value="0.3625" />
-        <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/login_activity.xml" value="0.1" />
+        <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/login_activity.xml" value="0.264" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/reset_password_activity.xml" value="0.3484375" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/reset_password_fragment.xml" value="0.3625" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/sign_up_activity.xml" value="0.264" />

--- a/Code/.idea/misc.xml
+++ b/Code/.idea/misc.xml
@@ -7,6 +7,8 @@
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/activity_main.xml" value="0.3625" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/fragment_settings.xml" value="0.3625" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/login_activity.xml" value="0.1" />
+        <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/reset_password_activity.xml" value="0.3484375" />
+        <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/reset_password_fragment.xml" value="0.3625" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/layout/sign_up_activity.xml" value="0.264" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/menu/bottom_nav_menu.xml" value="0.3625" />
         <entry key="..\:/Users/Aditya/Desktop/School-SFU/CMPT362/Fitcheck/code/app/src/main/res/xml/root_preferences.xml" value="0.3625" />

--- a/Code/app/src/main/AndroidManifest.xml
+++ b/Code/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.cmpt362.fitcheck">
 
+    <uses-feature android:name="android.hardware.camera" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -13,6 +16,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Fitcheck"
         tools:targetApi="31">
+        <activity
+            android:name=".ui.settings.ResetPasswordActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
         <activity
             android:name=".ui.calendar.DetailActivity"
             android:exported="false"

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/firebase/Firebase.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/firebase/Firebase.kt
@@ -13,6 +13,7 @@ import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
@@ -61,6 +62,10 @@ object Firebase {
 
     fun isUserSignedIn(): Boolean {
         return auth.currentUser != null
+    }
+
+    fun getUser(): FirebaseUser? {
+        return auth.currentUser
     }
 
     fun signInUser(email: String, password: String): Task<AuthResult> {

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/AuthenticationUtil.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/AuthenticationUtil.kt
@@ -1,11 +1,11 @@
 package com.cmpt362.fitcheck.ui.authentication
 
+import android.content.res.Resources
 import android.util.Patterns
+import com.cmpt362.fitcheck.R
 import java.util.regex.Pattern
 
 object AuthenticationUtil {
-
-    const val MIN_PASSWORD_LENGTH = 6
 
     fun isValidEmail(email: CharSequence?): Boolean {
         return if (email.isNullOrBlank()) {
@@ -13,6 +13,14 @@ object AuthenticationUtil {
         } else {
             val emailPattern: Pattern = Patterns.EMAIL_ADDRESS
             emailPattern.matcher(email).matches()
+        }
+    }
+
+    fun isValidPassword(password: CharSequence?, resources: Resources): Boolean {
+        return if (password.isNullOrBlank()) {
+            false
+        } else {
+            return password.length > resources.getInteger(R.integer.minimum_password_length)
         }
     }
 }

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/AuthenticationUtil.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/AuthenticationUtil.kt
@@ -20,7 +20,7 @@ object AuthenticationUtil {
         return if (password.isNullOrBlank()) {
             false
         } else {
-            return password.length > resources.getInteger(R.integer.minimum_password_length)
+            return password.length >= resources.getInteger(R.integer.minimum_password_length)
         }
     }
 }

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/LoginActivity.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/LoginActivity.kt
@@ -19,42 +19,39 @@ class LoginActivity : AppCompatActivity() {
     private lateinit var passwordText: EditText
     private lateinit var signInButton: Button
     private lateinit var signUpTV: TextView
-    private val EMAIL_KEY = "EMAIL_KEY"
-    private val PASSWORD_KEY = "PASSWORD_KEY"
+
+    private var emailIsValid = false
+    private var passwordIsValid = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.login_activity)
 
-        initializeVariables(savedInstanceState)
+        initializeVariables()
     }
 
-    private fun initializeVariables(savedInstanceState: Bundle?) {
+    private fun initializeVariables() {
         emailText = findViewById(R.id.signInEmail)
         passwordText = findViewById(R.id.signInPassword)
         signInButton = findViewById(R.id.signInButton)
         signUpTV = findViewById(R.id.noAccountSignUp)
 
-        val maybeEmail = savedInstanceState?.getString(EMAIL_KEY)
-        if (maybeEmail != null) {
-            emailText.setText(maybeEmail)
-        }
-
-        val maybePassword = savedInstanceState?.getString(PASSWORD_KEY)
-        if (maybePassword != null) {
-            passwordText.setText(maybePassword)
-        }
-
-        emailText.doOnTextChanged { text, start, before, count ->
-            if (text.toString().isNotEmpty()) {
-                checkIfAbleToSignIn()
+        emailText.doOnTextChanged { text, _, _, _ ->
+            emailIsValid = if (text.toString().isNotEmpty()) {
+                AuthenticationUtil.isValidEmail(text)
+            } else {
+                false
             }
+            signInButton.isEnabled = emailIsValid && passwordIsValid
         }
 
-        passwordText.doOnTextChanged { text, start, before, count ->
-            if (text.toString().isNotEmpty()) {
-                checkIfAbleToSignIn()
+        passwordText.doOnTextChanged { text, _, _, _ ->
+            passwordIsValid = if (text.toString().isNotEmpty()) {
+                AuthenticationUtil.isValidPassword(text, resources)
+            } else {
+                false
             }
+            signInButton.isEnabled = emailIsValid && passwordIsValid
         }
 
         signUpTV.setOnClickListener {
@@ -62,23 +59,7 @@ class LoginActivity : AppCompatActivity() {
         }
     }
 
-    private fun checkIfAbleToSignIn() {
-        val emailIsEmpty = emailText.text.toString().isEmpty()
-        val passwordIsEmpty = passwordText.text.toString().isEmpty()
-
-        signInButton.isEnabled = !(emailIsEmpty || passwordIsEmpty)
-    }
-
-    fun attemptSignIn(view: View) {
-        if (!AuthenticationUtil.isValidEmail(emailText.text)) {
-            emailText.error = getString(R.string.invalid_email_format)
-        } else {
-            emailText.error = null
-            signInUser()
-        }
-    }
-
-    private fun signInUser() {
+    fun signInUser(view: View) {
         val email = emailText.text.toString()
         val password = passwordText.text.toString()
 
@@ -95,11 +76,5 @@ class LoginActivity : AppCompatActivity() {
                         Toast.LENGTH_SHORT).show()
                 }
             }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putString(EMAIL_KEY, emailText.text.toString())
-        outState.putString(PASSWORD_KEY, passwordText.text.toString())
     }
 }

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/SignUpActivity.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/ui/authentication/SignUpActivity.kt
@@ -19,42 +19,39 @@ class SignUpActivity : AppCompatActivity() {
     private lateinit var passwordText: EditText
     private lateinit var signUpButton: Button
     private lateinit var signInTV: TextView
-    private val EMAIL_KEY = "EMAIL_KEY"
-    private val PASSWORD_KEY = "PASSWORD_KEY"
+
+    private var emailIsValid = false
+    private var passwordIsValid = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.sign_up_activity)
 
-        initializeVariables(savedInstanceState)
+        initializeVariables()
     }
 
-    private fun initializeVariables(savedInstanceState: Bundle?) {
+    private fun initializeVariables() {
         emailText = findViewById(R.id.signUpEmail)
         passwordText = findViewById(R.id.signUpPassword)
         signUpButton = findViewById(R.id.signUpButton)
         signInTV = findViewById(R.id.accountSignIn)
 
-        val maybeEmail = savedInstanceState?.getString(EMAIL_KEY)
-        if (maybeEmail != null) {
-            emailText.setText(maybeEmail)
-        }
-
-        val maybePassword = savedInstanceState?.getString(PASSWORD_KEY)
-        if (maybePassword != null) {
-            passwordText.setText(maybePassword)
-        }
-
         emailText.doOnTextChanged { text, _, _, _ ->
-            if (text.toString().isNotEmpty()) {
-                checkIfAbleToSignUp()
+            emailIsValid = if (text.toString().isNotEmpty()) {
+                AuthenticationUtil.isValidEmail(text)
+            } else {
+                false
             }
+            signUpButton.isEnabled = emailIsValid && passwordIsValid
         }
 
         passwordText.doOnTextChanged { text, _, _, _ ->
-            if (text.toString().isNotEmpty()) {
-                checkIfAbleToSignUp()
+            passwordIsValid = if (text.toString().isNotEmpty()) {
+                AuthenticationUtil.isValidPassword(text, resources)
+            } else {
+                false
             }
+            signUpButton.isEnabled = emailIsValid && passwordIsValid
         }
 
         signInTV.setOnClickListener {
@@ -63,24 +60,7 @@ class SignUpActivity : AppCompatActivity() {
         }
     }
 
-    private fun checkIfAbleToSignUp() {
-        val emailIsEmpty = emailText.text.toString().isEmpty()
-        val passwordIsEmpty = passwordText.text.toString().isEmpty()
-        val passwordNotLongEnough = passwordText.text.toString().length < AuthenticationUtil.MIN_PASSWORD_LENGTH
-
-        signUpButton.isEnabled = !(emailIsEmpty || passwordIsEmpty || passwordNotLongEnough)
-    }
-
-    fun attemptSignUp(view: View) {
-        if (!AuthenticationUtil.isValidEmail(emailText.text)) {
-            emailText.error = getString(R.string.invalid_email_format)
-        } else {
-            emailText.error = null
-            signUpUser()
-        }
-    }
-
-    private fun signUpUser() {
+    fun signUpUser(view: View) {
         val email = emailText.text.toString()
         val password = passwordText.text.toString()
 
@@ -97,11 +77,5 @@ class SignUpActivity : AppCompatActivity() {
                         Toast.LENGTH_SHORT).show()
                 }
             }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putString(EMAIL_KEY, emailText.text.toString())
-        outState.putString(PASSWORD_KEY, passwordText.text.toString())
     }
 }

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/ui/settings/ResetPasswordActivity.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/ui/settings/ResetPasswordActivity.kt
@@ -3,15 +3,53 @@ package com.cmpt362.fitcheck.ui.settings
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import androidx.core.widget.doOnTextChanged
 import com.cmpt362.fitcheck.R
+import com.cmpt362.fitcheck.ui.authentication.AuthenticationUtil
 
 class ResetPasswordActivity : AppCompatActivity() {
+
+    private lateinit var currentPasswordText: EditText
+    private lateinit var newPasswordText: EditText
+    private lateinit var changePasswordButton: Button
+
+    private var currentPasswordIsValid = false
+    private var newPasswordIsValid = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.reset_password_activity)
+
+        initVariables()
+    }
+
+    private fun initVariables() {
+        currentPasswordText = findViewById(R.id.currentPassword)
+        newPasswordText = findViewById(R.id.newPassword)
+        changePasswordButton = findViewById(R.id.changePasswordButton)
+
+        currentPasswordText.doOnTextChanged { text, _, _, _ ->
+            currentPasswordIsValid = if (text.toString().isNotEmpty()) {
+                AuthenticationUtil.isValidPassword(text, resources)
+            } else {
+                false
+            }
+            changePasswordButton.isEnabled = currentPasswordIsValid && newPasswordIsValid
+        }
+
+        newPasswordText.doOnTextChanged { text, _, _, _ ->
+            newPasswordIsValid = if (text.toString().isNotEmpty()) {
+                AuthenticationUtil.isValidPassword(text, resources)
+            } else {
+                false
+            }
+            changePasswordButton.isEnabled = currentPasswordIsValid && newPasswordIsValid
+        }
     }
 
     fun onSavePassword(view: View) {
-        
+
     }
 }

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/ui/settings/ResetPasswordActivity.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/ui/settings/ResetPasswordActivity.kt
@@ -5,15 +5,20 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import android.widget.EditText
+import android.widget.TextView
+import android.widget.Toast
 import androidx.core.widget.doOnTextChanged
 import com.cmpt362.fitcheck.R
+import com.cmpt362.fitcheck.firebase.Firebase
 import com.cmpt362.fitcheck.ui.authentication.AuthenticationUtil
+import com.google.firebase.auth.EmailAuthProvider
 
 class ResetPasswordActivity : AppCompatActivity() {
 
     private lateinit var currentPasswordText: EditText
     private lateinit var newPasswordText: EditText
     private lateinit var changePasswordButton: Button
+    private lateinit var resetPasswordErrorTV: TextView
 
     private var currentPasswordIsValid = false
     private var newPasswordIsValid = false
@@ -29,6 +34,7 @@ class ResetPasswordActivity : AppCompatActivity() {
         currentPasswordText = findViewById(R.id.currentPassword)
         newPasswordText = findViewById(R.id.newPassword)
         changePasswordButton = findViewById(R.id.changePasswordButton)
+        resetPasswordErrorTV = findViewById(R.id.resetPasswordErrorMessage)
 
         currentPasswordText.doOnTextChanged { text, _, _, _ ->
             currentPasswordIsValid = if (text.toString().isNotEmpty()) {
@@ -50,6 +56,30 @@ class ResetPasswordActivity : AppCompatActivity() {
     }
 
     fun onSavePassword(view: View) {
-
+        val user = Firebase.getUser()
+        if (user != null) {
+            val credential = EmailAuthProvider.getCredential(user.email!!, currentPasswordText.text.toString())
+            user.reauthenticate(credential)
+                .addOnCompleteListener { reauthenticateResult ->
+                    if (reauthenticateResult.isSuccessful) {
+                        user.updatePassword(newPasswordText.text.toString())
+                            .addOnCompleteListener { updatePasswordResult ->
+                                if (updatePasswordResult.isSuccessful) {
+                                    println("debug: Password changed successfully")
+                                    Toast.makeText(baseContext, "Password changed",
+                                        Toast.LENGTH_SHORT).show()
+                                    resetPasswordErrorTV.text = ""
+                                    finish()
+                                } else {
+                                    println("debug: unable to change password. Error message: ${updatePasswordResult.exception?.message}")
+                                    resetPasswordErrorTV.text = updatePasswordResult.exception?.message
+                                }
+                            }
+                    } else {
+                        println("debug: unable to re-authenticate user. Error message: ${reauthenticateResult.exception?.message}")
+                        resetPasswordErrorTV.text = reauthenticateResult.exception?.message
+                    }
+                }
+        }
     }
 }

--- a/Code/app/src/main/java/com/cmpt362/fitcheck/ui/settings/ResetPasswordActivity.kt
+++ b/Code/app/src/main/java/com/cmpt362/fitcheck/ui/settings/ResetPasswordActivity.kt
@@ -1,0 +1,17 @@
+package com.cmpt362.fitcheck.ui.settings
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.view.View
+import com.cmpt362.fitcheck.R
+
+class ResetPasswordActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.reset_password_activity)
+    }
+
+    fun onSavePassword(view: View) {
+        
+    }
+}

--- a/Code/app/src/main/res/layout/login_activity.xml
+++ b/Code/app/src/main/res/layout/login_activity.xml
@@ -48,7 +48,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/signInButton"
-            android:onClick="attemptSignIn"
+            android:onClick="signInUser"
             android:enabled="false"
             android:layout_margin="@dimen/sign_in_up_text_margin"
             android:text="@string/sign_in">

--- a/Code/app/src/main/res/layout/reset_password_activity.xml
+++ b/Code/app/src/main/res/layout/reset_password_activity.xml
@@ -45,6 +45,7 @@
                 android:text="@string/current_password">
             </TextView>
             <EditText
+                android:id="@+id/currentPassword"
                 android:layout_width="@dimen/full_screen_edit_text_width"
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="@dimen/label_to_content_vertical_margin"
@@ -66,6 +67,7 @@
                 android:text="@string/new_password">
             </TextView>
             <EditText
+                android:id="@+id/newPassword"
                 android:layout_width="@dimen/full_screen_edit_text_width"
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="@dimen/label_to_content_vertical_margin"
@@ -79,6 +81,7 @@
     </LinearLayout>
 
     <Button
+        android:id="@+id/changePasswordButton"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/Code/app/src/main/res/layout/reset_password_activity.xml
+++ b/Code/app/src/main/res/layout/reset_password_activity.xml
@@ -16,7 +16,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/reset_password"
-            android:textColor="@color/black"
             android:textSize="@dimen/sub_settings_header_size"
             android:layout_marginVertical="@dimen/heading_to_subheading_vertical_margin">
         </TextView>

--- a/Code/app/src/main/res/layout/reset_password_activity.xml
+++ b/Code/app/src/main/res/layout/reset_password_activity.xml
@@ -78,11 +78,19 @@
 
         </LinearLayout>
 
+        <TextView
+            android:id="@+id/resetPasswordErrorMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/error">
+        </TextView>
+
     </LinearLayout>
 
     <Button
         android:id="@+id/changePasswordButton"
         android:layout_width="fill_parent"
+        android:enabled="false"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:text="@string/change_password"

--- a/Code/app/src/main/res/layout/reset_password_activity.xml
+++ b/Code/app/src/main/res/layout/reset_password_activity.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.settings.ResetPasswordActivity"
+    android:orientation="vertical"
+    android:layout_margin="@dimen/general_layout_margin">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/reset_password"
+            android:textColor="@color/black"
+            android:textSize="@dimen/sub_settings_header_size"
+            android:layout_marginVertical="@dimen/heading_to_subheading_vertical_margin">
+        </TextView>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/reset_password_instructions">
+        </TextView>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/heading_to_content_vertical_margin"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/current_password">
+            </TextView>
+            <EditText
+                android:layout_width="@dimen/full_screen_edit_text_width"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="@dimen/label_to_content_vertical_margin"
+                android:hint="@string/current_password"
+                android:autofillHints="password"
+                android:inputType="textPassword">
+            </EditText>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/new_password">
+            </TextView>
+            <EditText
+                android:layout_width="@dimen/full_screen_edit_text_width"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="@dimen/label_to_content_vertical_margin"
+                android:hint="@string/new_password"
+                android:inputType="textPassword"
+                android:autofillHints="password">
+            </EditText>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <Button
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/change_password"
+        android:onClick="onSavePassword">
+    </Button>
+
+</LinearLayout>

--- a/Code/app/src/main/res/layout/reset_password_activity.xml
+++ b/Code/app/src/main/res/layout/reset_password_activity.xml
@@ -82,7 +82,7 @@
             android:id="@+id/resetPasswordErrorMessage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/error">
+            android:textColor="@color/red_error">
         </TextView>
 
     </LinearLayout>

--- a/Code/app/src/main/res/layout/sign_up_activity.xml
+++ b/Code/app/src/main/res/layout/sign_up_activity.xml
@@ -61,7 +61,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/signUpButton"
-            android:onClick="attemptSignUp"
+            android:onClick="signUpUser"
             android:enabled="false"
             android:layout_margin="@dimen/sign_in_up_text_margin"
             android:text="@string/sign_up">

--- a/Code/app/src/main/res/values/colors.xml
+++ b/Code/app/src/main/res/values/colors.xml
@@ -10,5 +10,5 @@
     <color name="blue_700">#67A2E1</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="error">#FF0000</color>
+    <color name="red_error">#FF0000</color>
 </resources>

--- a/Code/app/src/main/res/values/colors.xml
+++ b/Code/app/src/main/res/values/colors.xml
@@ -10,4 +10,5 @@
     <color name="blue_700">#67A2E1</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="error">#FF0000</color>
 </resources>

--- a/Code/app/src/main/res/values/dimens.xml
+++ b/Code/app/src/main/res/values/dimens.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- ========================== Margins and Others ========================= -->
+    <!-- ========================== Margins ========================= -->
 
     <dimen name="sign_in_up_text_margin">15dp</dimen>
     <dimen name="sign_in_fields_width">200dp</dimen>
     <dimen name="sign_in_fields_margin">20dp</dimen>
+    <dimen name="heading_to_content_vertical_margin">45dp</dimen>
+    <dimen name="heading_to_content_horizontal_margin">45dp</dimen>
+    <dimen name="heading_to_content_margin">45dp</dimen>
+    <dimen name="general_layout_margin">16dp</dimen>
+    <dimen name="general_horizontal_margin">16dp</dimen>
+    <dimen name="general_vertical_margin">16dp</dimen>
+    <dimen name="heading_to_subheading_vertical_margin">16dp</dimen>
+    <dimen name="label_to_content_vertical_margin">12dp</dimen>
+    <dimen name="label_to_content_horizontal_margin">12dp</dimen>
+    <dimen name="label_to_content_margin">12dp</dimen>
+    <dimen name="fab_margin">16dp</dimen>
+
+    <!-- ========================== EditTexts ========================= -->
+    <dimen name="full_screen_edit_text_width">300dp</dimen>
 
     <!-- ========================== Font sizes ========================= -->
-
     <dimen name="sign_in_up_text_size">20sp</dimen>
-    <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="fab_margin">16dp</dimen>
+    <dimen name="sub_settings_header_size">20sp</dimen>
 
 </resources>

--- a/Code/app/src/main/res/values/integers.xml
+++ b/Code/app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="minimum_password_length">6</integer>
+</resources>

--- a/Code/app/src/main/res/values/strings.xml
+++ b/Code/app/src/main/res/values/strings.xml
@@ -58,4 +58,10 @@
     <string name="logout">Log out</string>
     <string name="logout_summary">Log out of your account</string>
 
+    <!--    Reset Password  -->
+    <string name="current_password">Current Password</string>
+    <string name="reset_password_instructions">To change your password, you must enter your current password and a new one. Password must be at least 6 characters long.</string>
+    <string name="new_password">New password</string>
+    <string name="change_password">Change password</string>
+
 </resources>

--- a/Code/app/src/main/res/xml/root_preferences.xml
+++ b/Code/app/src/main/res/xml/root_preferences.xml
@@ -1,4 +1,5 @@
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory app:title="@string/account_info_header">
         <Preference
@@ -17,14 +18,18 @@
         <Preference
             app:key="@string/reset_password"
             app:title="@string/reset_password"
-            app:summary="@string/reset_password_summary"
-            app:fragment="com.ui.settings.ResetPasswordFragment" />
+            app:summary="@string/reset_password_summary">
+            <intent
+                android:targetPackage="com.cmpt362.fitcheck"
+                android:targetClass="com.cmpt362.fitcheck.ui.settings.ResetPasswordActivity">
+            </intent>
+        </Preference>
 
         <Preference
             app:key="@string/change_email"
             app:title="@string/change_email"
             app:summary="@string/change_email_summary"
-            app:fragment="com.ui.settings.ChangeEmailFragment" />
+            app:fragment="com.cmpt362.fitcheck.ui.settings.ChangeEmailFragment" />
 
         <Preference
             app:key="@string/logout"


### PR DESCRIPTION
Clicking on reset password from settings will open a reset password activity. The user must put in their current password and a new one in order to change the password. If the inputted current password is not correct, the user will be shown an error. Passwords must be at least 6 characters long in order for the button to be enabled. 

I refactored our login and sign up code to accommodate the reset password code.

Closes #30 